### PR TITLE
Fix wrong HTML encoding of "´"

### DIFF
--- a/textfilter/vibe/textfilter/html.d
+++ b/textfilter/vibe/textfilter/html.d
@@ -188,3 +188,15 @@ private struct StringAppender {
 		data ~= dst[0 .. encode(dst, ch)];
 	}
 }
+
+
+unittest {
+	// ASCII special characters
+	auto str1 = "!\"#$%&'()*+,-./:;<=>?[\\]^_`{|}~";
+	assert(htmlEscape(str1) == "!\"#$%&amp;'()*+,-./:;&lt;=&gt;?[\\]^_`{|}~");
+	assert(htmlAttribEscape(str1) == "!&quot;#$%&amp;&#39;()*+,-./:;&lt;=&gt;?[\\]^_`{|}~");
+
+	// non-ASCII special characters
+	auto str2 = " ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿";
+	assert(htmlEscape(str2) == str2);
+}

--- a/textfilter/vibe/textfilter/html.d
+++ b/textfilter/vibe/textfilter/html.d
@@ -159,7 +159,7 @@ void filterHTMLEscape(R)(ref R dst, dchar ch, HTMLEscapeFlags flags = HTMLEscape
 		case '0': .. case '9': goto case;
 		case ' ', '\t', '-', '_', '.', ':', ',', ';',
 			 '#', '+', '*', '?', '=', '(', ')', '/', '!',
-			 '%' , '{', '}', '[', ']', '`', '´', '$', '^', '~':
+			 '%' , '{', '}', '[', ']', '`', '$', '^', '~':
 			put(dst, cast(char)ch);
 			break;
 		case '<': put(dst, "&lt;"); break;


### PR DESCRIPTION
'´' is outside of the ASCII range and thus cannot be directly converted to a UTF-8 code unit.