### PR TITLE
feat(url): Expose 'isDirectory' on normalized as well

### DIFF
--- a/source/vibe/inet/url.d
+++ b/source/vibe/inet/url.d
@@ -539,10 +539,10 @@ struct URL {
 
 		See `normalize` for a full description.
 	*/
-	URL normalized()
+	URL normalized(bool isDirectory = false)
 	const {
 		URL ret = this;
-		ret.normalize();
+		ret.normalize(isDirectory);
 		return ret;
 	}
 


### PR DESCRIPTION
There should be feature parity between the in-place and non-modifying overloads.